### PR TITLE
A rewritten mustache parser, properly handles in-string and not-in-string values

### DIFF
--- a/lib/mustache-parser.pegjs
+++ b/lib/mustache-parser.pegjs
@@ -1,0 +1,93 @@
+start = newMustache
+
+// Returns an object with this shape:
+// {
+//   name: string,
+//   attrs: array, (items look like 'class="abc"', 'tagName="xyz"', '(query-params foo=bar)', 'blah', '"quotedBlah"', etc)
+//   modifier: '?' or '!' (optional),
+// }
+newMustache = name:newMustacheStart m_* attrs:newMustacheAttr* {
+  attrs = attrs.concat(name.shorthands);
+
+  var ret = {
+    name: name.name,
+    attrs: attrs
+  };
+  if (name.modifier) {
+    ret.modifier = name.modifier;
+  }
+
+  return ret;
+}
+
+newMustacheStart = name:newMustacheName m_* shorthands:newMustacheShortHand* {
+  return {
+    name: name.name,
+    modifier: name.modifier,
+    shorthands: shorthands
+  };
+}
+
+// shorthand %tagName, .className, #idName
+newMustacheShortHand = m_shortHandTagName / m_shortHandIdName / m_shortHandClassName
+
+m_shortHandTagName = '%' tagName:newMustacheShortHandName {
+  return 'tagName="' + tagName + '"';
+}
+
+m_shortHandIdName = '#' idName:newMustacheShortHandName {
+  return 'elementId="' + idName + '"';
+}
+
+m_shortHandClassName = '.' className:newMustacheShortHandName {
+  return 'class="' + className + '"';
+}
+
+newMustacheShortHandName = $([A-Za-z0-9-]+)
+
+newMustacheName = !m_invalidNameStartChar name:$newMustacheNameChar+ modifier:m_modifierChar? {
+  return {
+    name: name,
+    modifier: modifier
+  };
+}
+
+m_invalidNameStartChar = '.' / '-' / [0-9]
+
+// unbound (!) and conditional (?) modifiers
+m_modifierChar = '!' / '?'
+
+// a character that can be in a mustache name
+newMustacheNameChar = [A-Za-z0-9-] / '.'
+
+newMustacheAttr = m_keyValue / m_parenthetical / newMustacheAttrValue
+
+m_keyValue = attrName:newMustacheAttrName m_* '=' m_* attrValue:newMustacheAttrValue m_* {
+  return attrName + '=' + attrValue;
+}
+
+newMustacheAttrName = $newMustacheNameChar+
+
+newMustacheAttrValue = v:$(m_quotedString / m_valuePath) m_* {
+  return v;
+}
+
+m_valuePath = $newMustacheNameChar+
+
+m_quotedString = ( '"' m_stringWithoutDouble '"' ) / ("'" m_stringWithoutSingle "'")
+
+m_stringWithoutDouble = $(m_inStringChar / "'")+
+m_stringWithoutSingle = $(m_inStringChar / '"')+
+
+m_inStringChar = [^'"]
+m_inParensChar = [^\(\)]
+m_commentChar = '/'
+
+m_parenthetical
+= m_* p:$(m_OPEN_PAREN m_inParensChar* m_parenthetical? m_inParensChar* m_CLOSE_PAREN) m_* {
+  return p;
+}
+
+m_OPEN_PAREN = '('
+m_CLOSE_PAREN = ')'
+m_ = ' '

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -1,6 +1,9 @@
 {
   var builder = options.builder;
 
+  var UNBOUND_MODIFIER = '!';
+  var CONDITIONAL_MODIFIER = '?';
+
   var SELF_CLOSING_TAG = {
     area: true,
     base: true,
@@ -53,14 +56,6 @@
     "submit": true, "input": true, "change": true, "dragStart": true,
     "drag": true, "dragEnter": true, "dragLeave": true,
     "dragOver": true, "drop": true, "dragEnd": true
-  };
-
-  function prepareHelper(content, escaped) {
-    if (/^[A-Z]/.test(content)) {
-      content = 'view '+content;
-    }
-
-    return content;
   };
 
   function prepareMustachValue(content){
@@ -118,9 +113,54 @@
     return ret;
   }
 
-  function createBlockOrMustache(mustacheTuple, escaped) {
-    var mustacheContent = mustacheTuple[0];
+  // attrs are simple strings,
+  // combine all the ones that start with 'class='
+  function coalesceAttrs(attrs){
+    var classes = [];
+    var newAttrs = [];
+    var classRegex = /^class="(.*)"$/;
+    var match;
+
+    for (var i=0,l=attrs.length; i<l; i++) {
+      var attr = attrs[i];
+      if (match = attr.match(classRegex)) {
+        classes.push(match[1]);
+      } else {
+        newAttrs.push(attr);
+      }
+    }
+
+    if (classes.length) {
+      newAttrs.push('class="' + classes.join(' ') + '"');
+    }
+    return newAttrs;
+  }
+
+  function createBlockOrMustache(mustacheTuple) {
+    var mustache   = mustacheTuple[0];
     var blockTuple = mustacheTuple[1];
+
+    var escaped    = mustache.isEscaped;
+    var mustacheContent = mustache.name;
+    var mustacheAttrs = mustache.attrs;
+
+    if (mustacheAttrs.length) {
+      var attrs = coalesceAttrs(mustacheAttrs);
+      mustacheContent += ' ' + attrs.join(' ');
+    }
+
+    if (mustache.isViewHelper) {
+      mustacheContent = 'view ' + mustacheContent;
+    }
+
+    if (mustache.modifier === UNBOUND_MODIFIER) {
+      mustacheContent = 'unbound ' + mustacheContent;
+    }
+
+    if (mustache.modifier === CONDITIONAL_MODIFIER) {
+      mustacheContent = 'if ' + mustacheContent;
+    }
+
     if (blockTuple) {
       var block = builder.generateBlock(mustacheContent, escaped);
       builder.enter(block);
@@ -374,11 +414,12 @@ legacyPartialName
     return new AST.PartialNameNode(new AST.StringNode(s));
   }
 
-// Returns [MustacheNode] or [BlockNode]
 mustache
-  = m:(explicitMustache / lineStartingMustache)
+  = mustacheTuple:(explicitMustache / lineStartingMustache)
 {
-  return [m];
+  var mustacheOrBlock = createBlockOrMustache(mustacheTuple);
+
+  return [mustacheOrBlock];
 }
 
 
@@ -392,19 +433,19 @@ inlineComment
   = '/' lineContent
 
 lineStartingMustache
-  = mustache:(capitalizedLineStarterMustache / mustacheOrBlock)
+  = mustacheTuple:(capitalizedLineStarterMustache / mustacheOrBlock)
 {
-  var preparedMustache = [
-    prepareMustachValue( prepareHelper(mustache[0]) ),
-    mustache[1]
-  ];
-  return createBlockOrMustache(preparedMustache, true);
+  return mustacheTuple;
 }
 
 capitalizedLineStarterMustache
-  = &[A-Z] ret:mustacheOrBlock
+  = &[A-Z] mustacheTuple:mustacheOrBlock
 {
-  return ret;
+  var mustache = mustacheTuple[0];
+  var block = mustacheTuple[1];
+  mustache.isViewHelper = true;
+
+  return [mustache, block];
 }
 
 // (Possibly multi-line) text content beginning on the same
@@ -437,7 +478,10 @@ unindentedContent = blankLine* c:content DEDENT { return c; }
 // terminator.
 htmlTerminator
   = colonContent
-  / _ m:explicitMustache { return [m]; }
+  / _ mustacheTuple:explicitMustache {
+    var blockOrMustache = createBlockOrMustache(mustacheTuple);
+    return [blockOrMustache];
+  }
   / _ inlineComment? TERM c:indentedContent? { return c; }
   / _ inlineComment? ']' TERM  c:unindentedContent? { return c; } // bracketed
   / h:htmlNestedTextNodes { return h;}
@@ -455,7 +499,7 @@ htmlElement = h:inHtmlTag nested:htmlTerminator
   return [builder.exit()];
 }
 
-mustacheOrBlock = mustacheContent:inMustache _ inlineComment?blockTuple:mustacheNestedContent
+mustacheOrBlock = mustacheContent:inMustache _ inlineComment? blockTuple:mustacheNestedContent
 {
   if (blockTuple) {
     return [mustacheContent, blockTuple];
@@ -480,69 +524,22 @@ mustacheNestedContent
 
 explicitMustache = e:equalSign mustacheTuple:mustacheOrBlock
 {
-  var preparedMustacheTuple = [
-    prepareMustachValue( mustacheTuple[0] ),
-    mustacheTuple[1]
-  ];
-  return createBlockOrMustache(preparedMustacheTuple, e);
+  var mustache = mustacheTuple[0];
+  var block = mustacheTuple[1];
+
+  mustache.isEscaped = e;
+
+  return [mustache, block];
 }
 
 inMustache
-  = isPartial:'>'? !('[' TERM) _ mustacheContent:inMustacheContent+ inlineComment? {
+  = isPartial:'>'? !('[' TERM) _ mustache:newMustache inlineComment? {
   if(isPartial) {
     var n = new AST.PartialNameNode(new AST.StringNode(sexpr.id.string));
     return new AST.PartialNode(n, sexpr.params[0], undefined, {});
   }
-
-  return mustacheContent.join('').trim();
+  return mustache;
 }
-
-inMustacheContent
- = mustacheText:$mustacheTextNode+ mustacheAttrs:htmlMustacheAttribute* stringWithQuotes? {
-   mustacheText = mustacheText.trim();
-
-   var mustacheParts = [];
-   var classNames = [];
-
-   // mustacheText might have greedily matched a space and then .classname, so
-   // the mustacheText needs to be checked for that
-   // to handle the case of, e.g., "MyView .classname" -> {{MyView class="classname"}}
-
-   var parts = mustacheText.split(' ');
-   for (var i=0,l=parts.length; i<l; i++){
-     if (parts[i].charAt(0) !== '.') {
-       mustacheParts.push(parts[i]);
-     } else {
-       classNames = classNames.concat( parts[i].split('.').slice(1) );
-     }
-   }
-
-   // rejoin the non-classname parts of the mustache text
-   mustacheText = mustacheParts.join(' ');
-
-   // mustacheAttrs are of form [key,value] like ['tagName','span'] or ['class','foo']
-   // Append them to mustacheText unless they are class attrs, so we can coalesce those
-   if (mustacheAttrs.length) {
-     for (var i=0,l=mustacheAttrs.length; i<l; i++){
-       if (mustacheAttrs[i][0] === 'class') {
-         classNames.push( mustacheAttrs[i][1] ); // defer
-       } else {
-         mustacheText += ' ' + mustacheAttrs[i][0] + '=' + '"' + mustacheAttrs[i][1] + '"';
-       }
-     }
-   }
-
-   // finally, add all class names at once
-   if (classNames.length) {
-     mustacheText += ' class="' + classNames.join(' ') + '" ';
-   }
-
-   return mustacheText;
- }
-
-// FIXME need to distinguish between quoted strings and non. In quoted strings, everything should be allowed
-mustacheTextNode
-  = $(alpha / [0-9] / '_' / '.' / '-' / '=' / '!' / '?' / '"' / ',' / "'" / '@' / '(' / ')' / whitespace)
 
 sexpr
   = path:pathIdNode !' [' params:inMustacheParam* hash:hash?
@@ -864,6 +861,7 @@ actionValue
   = stringWithQuotes
   / id:pathIdNode { return id; }
 
+// FIXME this rule is never used
 quotedActionValue = p:('"' inMustache '"' / "'" inMustache "'") { return p[1]; }
 
 actionAttribute
@@ -977,3 +975,96 @@ whitespace "InlineWhitespace"
 lineChar = !(INDENT / DEDENT / TERM) c:. { return c; }
 lineContent = $lineChar*
 
+// ========== from mustache-parser.pegjs ======================================== //
+// Returns an object with this shape:
+// {
+//   name: string,
+//   attrs: array, (items look like 'class="abc"', 'tagName="xyz"', '(query-params foo=bar)', 'blah', '"quotedBlah"', etc)
+//   modifier: '?' or '!' (optional),
+// }
+newMustache = name:newMustacheStart m_* attrs:newMustacheAttr* {
+  attrs = attrs.concat(name.shorthands);
+
+  var ret = {
+    name: name.name,
+    attrs: attrs
+  };
+  if (name.modifier) {
+    ret.modifier = name.modifier;
+  }
+
+  return ret;
+}
+
+newMustacheStart = name:newMustacheName m_* shorthands:newMustacheShortHand* {
+  return {
+    name: name.name,
+    modifier: name.modifier,
+    shorthands: shorthands
+  };
+}
+
+// shorthand %tagName, .className, #idName
+newMustacheShortHand = m_shortHandTagName / m_shortHandIdName / m_shortHandClassName
+
+m_shortHandTagName = '%' tagName:newMustacheShortHandName {
+  return 'tagName="' + tagName + '"';
+}
+
+m_shortHandIdName = '#' idName:newMustacheShortHandName {
+  return 'elementId="' + idName + '"';
+}
+
+m_shortHandClassName = '.' className:newMustacheShortHandName {
+  return 'class="' + className + '"';
+}
+
+newMustacheShortHandName = $([A-Za-z0-9-]+)
+
+newMustacheName = !m_invalidNameStartChar name:$newMustacheNameChar+ modifier:m_modifierChar? {
+  return {
+    name: name,
+    modifier: modifier
+  };
+}
+
+m_invalidNameStartChar = '.' / '-' / [0-9]
+
+// unbound (!) and conditional (?) modifiers
+m_modifierChar = '!' / '?'
+
+// a character that can be in a mustache name
+newMustacheNameChar = [A-Za-z0-9-] / '.'
+
+newMustacheAttr = m_keyValue / m_parenthetical / newMustacheAttrValue
+
+m_keyValue = attrName:newMustacheAttrName m_* '=' m_* attrValue:newMustacheAttrValue m_* {
+  return attrName + '=' + attrValue;
+}
+
+newMustacheAttrName = $newMustacheNameChar+
+
+newMustacheAttrValue = v:$(m_quotedString / m_valuePath) m_* {
+  return v;
+}
+
+m_valuePath = $newMustacheNameChar+
+
+m_quotedString = ( '"' m_stringWithoutDouble '"' ) / ("'" m_stringWithoutSingle "'")
+
+m_stringWithoutDouble = $(m_inStringChar / "'")+
+m_stringWithoutSingle = $(m_inStringChar / '"')+
+
+m_inStringChar = [^'"]
+m_inParensChar = [^\(\)]
+m_commentChar = '/'
+
+m_parenthetical
+= m_* p:$(m_OPEN_PAREN m_inParensChar* m_parenthetical? m_inParensChar* m_CLOSE_PAREN) m_* {
+  return p;
+}
+
+m_OPEN_PAREN = '('
+m_CLOSE_PAREN = ')'
+m_ = ' '
+// =========      end of mustache-parser.pegjs ========================================= //

--- a/tests/index.html
+++ b/tests/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>QUnit Example</title>
+  <title>Emblem.js Tests</title>
   <link rel="stylesheet" href="qunit/qunit.css">
 </head>
 <body>

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -28,7 +28,7 @@ test("basic (click) followed by attr", function(assert){
   var emblem = 'button click="submitComment" class="foo" Submit Comment';
   assert.compilesTo(emblem, '<button {{action "submitComment" on="click"}} class="foo">Submit Comment</button>');
 
-  var emblem = 'button click="submitComment \'omg\'" class="foo" Submit Comment';
+  emblem = 'button click="submitComment \'omg\'" class="foo" Submit Comment';
   assert.compilesTo(emblem, '<button {{action "submitComment" \'omg\' on="click"}} class="foo">Submit Comment</button>');
 });
 
@@ -68,4 +68,3 @@ test("manual nested", function(assert){
   );
   assert.compilesTo(emblem, '<a {{action \'submitComment\' target=view}}><p>Submit Comment</p></a>');
 });
-

--- a/tests/integration/attributes-test.js
+++ b/tests/integration/attributes-test.js
@@ -165,7 +165,7 @@ test("tagName w/ space", function(assert) {
 });
 
 test("tagName block", function(assert) {
-  var emblem = "view App.FunView%span\n  p Hello";
+  var emblem = "App.FunView%span\n  p Hello";
   assert.compilesTo(emblem, '{{#view App.FunView tagName="span"}}<p>Hello</p>{{/view}}');
 });
 
@@ -190,8 +190,8 @@ test("mixed w/ hash`", function(assert) {
 });
 
 test("mixture of all`", function(assert) {
-  var emblem = "App.FunView%alex#hell.bork.snork funbags=\"yeah\"";
-  assert.compilesTo(emblem, '{{view App.FunView tagName="alex" elementId="hell" class="bork snork" funbags="yeah"}}');
+  var emblem = 'App.FunView%alex#hell.bork.snork funbags="yeah"';
+  assert.compilesTo(emblem, '{{view App.FunView funbags="yeah" tagName="alex" elementId="hell" class="bork snork"}}');
 });
 
 QUnit.module("attributes: bound and unbound");

--- a/tests/unit/mustache-parser-test.js
+++ b/tests/unit/mustache-parser-test.js
@@ -1,0 +1,205 @@
+/* global QUnit */
+import parse from 'emblem/mustache-parser';
+
+QUnit.module('mustache-parser');
+
+test('capitalized start', function(assert){
+  var text = 'App.Funview';
+
+  assert.deepEqual( parse(text), {
+    name: 'App.Funview',
+    attrs: []
+  });
+});
+
+test('lowercase start', function(assert){
+  var text = 'frank';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: []
+  });
+});
+
+test('lowercase unquoted attr value', function(assert){
+  var text = 'frank foo=bar';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['foo=bar']
+  });
+});
+
+test('attrs with spaces', function(assert){
+  var text = 'frank foo = bar boo = far';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['foo=bar', 'boo=far']
+  });
+});
+
+test('multiple attrs', function(assert){
+  var text = 'frank foo=bar boo=far';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['foo=bar', 'boo=far']
+  });
+});
+
+test('lowercase double-quoted attr value', function(assert){
+  var doubleQuote = 'input placeholder="\'100% /^%&*()x12#"';
+
+  assert.deepEqual( parse(doubleQuote), {
+    name: 'input',
+    attrs: ['placeholder="\'100% /^%&*()x12#"']
+  });
+});
+
+test('lowercase single-quoted attr value', function(assert){
+  var singleQuote = "input placeholder='\"100% /^%&*()x12#'";
+
+  assert.deepEqual( parse(singleQuote), {
+    name: 'input',
+    attrs: ["placeholder='\"100% /^%&*()x12#'"]
+  });
+});
+
+test('query-params', function(assert){
+  var text = 'frank (query-params groupId=defaultGroup.id)';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['(query-params groupId=defaultGroup.id)']
+  });
+});
+
+test('nested query-params', function(assert){
+  var text = 'frank (query-params groupId=defaultGroup.id (more-qp x=foo))';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['(query-params groupId=defaultGroup.id (more-qp x=foo))']
+  });
+});
+
+test('mixed query-params and key-value attrs', function(assert){
+  var text = 'frank (query-params abc=def) fob=bob (qp-2 dog=fog) dab=tab  ';
+
+  assert.deepEqual( parse(text), {
+    attrs: ['(query-params abc=def)',
+            'fob=bob',
+            '(qp-2 dog=fog)',
+            'dab=tab'],
+    name: 'frank'
+  });
+});
+
+test('mustache name with dash', function(assert){
+  var text = 'link-to foo=bar';
+
+  assert.deepEqual( parse(text), {
+    name: 'link-to',
+    attrs: ['foo=bar']
+  });
+});
+
+test('mustache with quoted param', function(assert){
+  var text = 'link-to "abc.def"';
+
+  assert.deepEqual( parse(text), {
+    name: 'link-to',
+    attrs: ['"abc.def"']
+  });
+});
+
+test('mustache with unquoted param', function(assert){
+  var text = 'link-to dog';
+
+  assert.deepEqual( parse(text), {
+    name: 'link-to',
+    attrs: ['dog']
+  });
+});
+
+test('mustache with multiple params', function(assert){
+  var text = 'link-to "dog.tag" dog';
+
+  assert.deepEqual( parse(text), {
+    name: 'link-to',
+    attrs: ['"dog.tag"', 'dog']
+  });
+});
+
+test('mustache with shorthand % syntax', function(assert){
+  var text = 'frank%span';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['tagName="span"']
+  });
+});
+
+test('mustache with shorthand # syntax', function(assert){
+  var text = 'frank#id-name';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['elementId="id-name"']
+  });
+});
+
+test('mustache with shorthand . syntax with required space', function(assert){
+  var text = 'frank .class-name';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['class="class-name"']
+  });
+});
+
+test('mustache with multiple classes', function(assert){
+  var text = 'frank .class-name1.class-name2';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['class="class-name1"',
+            'class="class-name2"']
+  });
+});
+
+test('mustache with multiple shorthands', function(assert){
+  var text = 'frank%span#my-id.class-name';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['tagName="span"', 'elementId="my-id"', 'class="class-name"']
+  });
+});
+
+test('mustache cannot start with a dot, a dash or a digit', function(assert){
+  assert.throws( function() { parse('.frank'); } );
+  assert.throws( function() { parse('-frank'); } );
+  assert.throws( function() { parse('9frank'); } );
+});
+
+test("bang modifier", function(assert) {
+  var text = 'foo!';
+
+  assert.deepEqual( parse(text), {
+    name: 'foo',
+    attrs: [],
+    modifier: '!'
+  });
+});
+
+test("conditional modifier", function(assert) {
+  var text = 'foo?';
+
+  assert.deepEqual( parse(text), {
+    name: 'foo',
+    attrs: [],
+    modifier: '?'
+  });
+});


### PR DESCRIPTION
@mixonic for you.
I rewrote the mustache-parsing code from scratch -- it is in `mustache-parser.pegjs` and unit tested separately from the big parser. The rule names are a bit funky because I wanted to be sure not to conflict with the existing rule names in the big parser.

It fixes the issue we had before of not knowing what characters to allow in a mustache because we didn't know if we were in a quoted string or not. It also simplifies the shape of a mustache object in the parser and allows for removal of a lot by-hand inspecting of strings (to determine if they start with a captial, end with a '?', etc)

I think a to-do for later will be to make the Brocfile inline the mustache-parser pegjs so it isn't duplicated between the two files.

cc @machty
