### PR TITLE
Print a better message if assertion fails

### DIFF
--- a/tests/support/integration-assertions.js
+++ b/tests/support/integration-assertions.js
@@ -1,4 +1,6 @@
 /*global QUnit*/
+
+import { w } from '../support/utils';
 import Emblem from '../../emblem';
 
 export function compilesTo( emblem, handlebars, message ) {
@@ -9,7 +11,12 @@ export function compilesTo( emblem, handlebars, message ) {
     if (messageEmblem.length > maxLenth) {
       messageEmblem = messageEmblem.slice(0,maxLenth) + '...';
     }
-    message = 'Expected "' + messageEmblem + '" to compile to "' + handlebars + '"';
+    message = w(
+      'compilesTo assertion failed:',
+      '\tEmblem:   "' + messageEmblem + '"',
+      '\tExpected: "' + handlebars + '"',
+      '\tActual:   "' + output + '"'
+    )
   }
   QUnit.push(output === handlebars, output, handlebars, message);
 };


### PR DESCRIPTION
I found this makes it a lot easier to see what is going on if tests fail using `npm test`.  It's not necessary in the browser though now that I see what that output looks like.  Again, feel free to close if you don't find it useful.
